### PR TITLE
lsコマンド（オブジェクト指向版）

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
 inherit_gem:
   rubocop-fjord:
     - "config/rubocop.yml"
+AllCops:
+  Exclude:
+    - "08.ls_object/test/**/*"

--- a/08.ls_object/command.rb
+++ b/08.ls_object/command.rb
@@ -1,0 +1,27 @@
+require 'optparse'
+require 'pathname'
+
+class Command
+  attr_reader :params
+  
+  def initialize
+    @ARGV = ARGV
+    @params = { detail: false, reverse: false, dot_match: false }
+    option_parse
+  end
+
+  def pathname
+    path = @ARGV[0] || '.'
+    pathname = Pathname(path).join('*')
+  end
+  
+  private
+  
+  def option_parse
+    opt = OptionParser.new
+    opt.on('-l') { |v| params[:detail] = v }
+    opt.on('-r') { |v| params[:reverse] = v }
+    opt.on('-a') { |v| params[:dot_match] = v }
+    opt.parse!(@ARGV)  
+  end
+end

--- a/08.ls_object/command.rb
+++ b/08.ls_object/command.rb
@@ -1,27 +1,29 @@
+# frozen_string_literal: true
+
 require 'optparse'
 require 'pathname'
 
 class Command
   attr_reader :params
-  
+
   def initialize
-    @ARGV = ARGV
+    @argv = ARGV
     @params = { detail: false, reverse: false, dot_match: false }
     option_parse
   end
 
   def pathname
-    path = @ARGV[0] || '.'
-    pathname = Pathname(path).join('*')
+    path = @argv[0] || '.'
+    Pathname(path).join('*')
   end
-  
+
   private
-  
+
   def option_parse
     opt = OptionParser.new
     opt.on('-l') { |v| params[:detail] = v }
     opt.on('-r') { |v| params[:reverse] = v }
     opt.on('-a') { |v| params[:dot_match] = v }
-    opt.parse!(@ARGV)  
+    opt.parse!(@argv)
   end
 end

--- a/08.ls_object/long_format.rb
+++ b/08.ls_object/long_format.rb
@@ -1,0 +1,65 @@
+require 'pathname'
+require 'etc'
+
+class LongFormat
+  MODE_TABLE = {
+    '7' => 'rwx',
+    '6' => 'rw-',
+    '5' => 'r-x',
+    '4' => 'r--',
+    '3' => '-wx',
+    '2' => '-w-',
+    '1' => '--x',
+    '0' => '---',
+  }
+
+  def initialize(filenames)
+    @pathnames =
+      filenames.map do |filename|
+        Pathname(filename)
+      end
+  end
+
+  def run_ls_long_format
+    block_total = 0
+    max_nlink = 0
+    max_user_length = 0
+    max_group_length = 0
+    max_size = 0
+    @pathnames.each do |pathname|
+      stat = pathname.stat
+      max_nlink = [max_nlink, stat.nlink.to_s.size].max
+      max_user_length = [max_user_length, Etc.getpwuid(stat.uid).name.size].max
+      max_group_length = [max_group_length, Etc.getgrgid(stat.gid).name.size].max
+      max_size = [max_size, stat.size.to_s.size].max
+      block_total += stat.blocks
+    end
+    rows = ["total #{block_total}"]
+    rows += @pathnames.map do |pathname|
+      format_table(pathname, max_nlink, max_user_length, max_group_length, max_size)
+    end
+    rows.join("\n")
+  end
+
+  def format_table(pathname, max_nlink, max_user_length, max_group_length, max_size)
+    stat = pathname.stat
+    ret = ''
+    ret += stat.file? ? '-' : 'd'
+    mode = sprintf("%#o", stat.mode.to_s)[-3..-1]
+    ret += format_mode(mode)
+    ret += "  #{stat.nlink.to_s.rjust(max_nlink)}"
+    ret += " #{Etc.getpwuid(stat.uid).name.rjust(max_user_length)}"
+    ret += "  #{Etc.getgrgid(stat.gid).name.rjust(max_group_length)}"
+    ret += "  #{stat.size.to_s.rjust(max_size)}"
+    ret += " #{stat.mtime.strftime("%_m %d %R")}"
+    ret += " #{pathname.basename}"
+  end
+
+  def format_mode(mode)
+    ret = ''
+    mode.each_char.map do |c|
+      ret += MODE_TABLE[c]
+    end
+    ret
+  end
+end

--- a/08.ls_object/long_format.rb
+++ b/08.ls_object/long_format.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 require 'etc'
 
@@ -10,8 +12,8 @@ class LongFormat
     '3' => '-wx',
     '2' => '-w-',
     '1' => '--x',
-    '0' => '---',
-  }
+    '0' => '---'
+  }.freeze
 
   def initialize(filenames)
     @pathnames =
@@ -45,14 +47,14 @@ class LongFormat
     stat = pathname.stat
     ret = ''
     ret += stat.file? ? '-' : 'd'
-    mode = sprintf("%#o", stat.mode.to_s)[-3..-1]
+    mode = format('%#o', stat.mode.to_s)[-3..-1]
     ret += format_mode(mode)
     ret += "  #{stat.nlink.to_s.rjust(max_nlink)}"
     ret += " #{Etc.getpwuid(stat.uid).name.rjust(max_user_length)}"
     ret += "  #{Etc.getgrgid(stat.gid).name.rjust(max_group_length)}"
     ret += "  #{stat.size.to_s.rjust(max_size)}"
-    ret += " #{stat.mtime.strftime("%_m %d %R")}"
-    ret += " #{pathname.basename}"
+    ret += " #{stat.mtime.strftime('%_m %d %R')}"
+    ret + " #{pathname.basename}"
   end
 
   def format_mode(mode)

--- a/08.ls_object/long_format.rb
+++ b/08.ls_object/long_format.rb
@@ -22,7 +22,7 @@ class LongFormat
       end
   end
 
-  def run_ls_long_format
+  def run
     row_data = @pathnames.map do |pathname|
       stat = pathname.stat
       build_data(pathname, stat)

--- a/08.ls_object/long_format.rb
+++ b/08.ls_object/long_format.rb
@@ -42,7 +42,7 @@ class LongFormat
       user: Etc.getpwuid(stat.uid).name,
       group: Etc.getgrgid(stat.gid).name,
       size: stat.size.to_s,
-      mtime: stat.mtime.strftime('%_m %d %R'),
+      mtime: stat.mtime.strftime('%_m %e %R'),
       filename: pathname.basename,
       block: stat.blocks
     }

--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -1,0 +1,29 @@
+require_relative './command'
+
+class Ls
+  def initialize(pathnames, params)
+    @params = params
+    @pathnames = pathnames
+  end
+
+  def run_ls
+    filenames =
+      if @params[:dot_match]
+        Dir.glob(@pathnames, File::FNM_DOTMATCH).sort
+      else
+        Dir.glob(@pathnames).sort
+      end
+    filenames = filenames.reverse if @params[:reverse]
+    if @params[:detail]
+      long_format = LongFormat.new(filenames)
+      long_format.run_ls_long_format
+    else
+      short_format = ShortFormat.new(filenames)
+      short_format.run_ls_short_format
+    end
+  end
+end
+
+command = Command.new
+ls = Ls.new(command.pathname, command.params)
+puts ls.run_ls

--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -1,5 +1,6 @@
 require_relative './command'
 require_relative './short_format'
+require_relative './long_format'
 
 class Ls
   def initialize(pathnames, params)

--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require_relative './command'
 require_relative './short_format'

--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -19,13 +19,9 @@ class Ls
         Dir.glob(@pathnames).sort
       end
     filenames = filenames.reverse if @params[:reverse]
-    if @params[:detail]
-      long_format = LongFormat.new(filenames)
-      long_format.run_ls_long_format
-    else
-      short_format = ShortFormat.new(filenames)
-      short_format.run_ls_short_format
-    end
+    
+    format = (@params[:detail] ? LongFormat : ShortFormat).new(filenames)
+    format.run
   end
 end
 

--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -1,4 +1,5 @@
 require_relative './command'
+require_relative './short_format'
 
 class Ls
   def initialize(pathnames, params)

--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 require_relative './command'
 require_relative './short_format'
 require_relative './long_format'

--- a/08.ls_object/short_format.rb
+++ b/08.ls_object/short_format.rb
@@ -1,0 +1,30 @@
+require 'pathname'
+
+class ShortFormat
+  DEFAULT_COL_COUNT = 3
+
+  def initialize(filenames)
+    @pathnames = 
+      filenames.map do |filename|
+        Pathname(filename)
+      end
+  end
+
+  def run_ls_short_format
+    filenames = @pathnames.map(&:basename).map(&:to_s)
+    max_filename_count = filenames.map(&:size).max
+    row_count = (filenames.count.to_f / DEFAULT_COL_COUNT).ceil
+    transposed_filenames = transpose_file(filenames.each_slice(row_count).to_a)
+    format_table(transposed_filenames, max_filename_count)
+  end
+
+  def transpose_file(filenames)
+    filenames[0].zip(*filenames[1..-1])
+  end
+
+  def format_table(filenames, max_filename_count)
+    filenames.map do |row_files|
+      row_files.map { |file| file.to_s.ljust(max_filename_count + 1) }.join.rstrip
+    end.join("\n")
+  end
+end

--- a/08.ls_object/short_format.rb
+++ b/08.ls_object/short_format.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 require 'pathname'
 
 class ShortFormat
   DEFAULT_COL_COUNT = 3
 
   def initialize(filenames)
-    @pathnames = 
+    @pathnames =
       filenames.map do |filename|
         Pathname(filename)
       end

--- a/08.ls_object/short_format.rb
+++ b/08.ls_object/short_format.rb
@@ -20,6 +20,8 @@ class ShortFormat
     format_table(transposed_filenames, max_filename_count)
   end
 
+  private
+
   def transpose_file(filenames)
     filenames[0].zip(*filenames[1..-1])
   end

--- a/08.ls_object/short_format.rb
+++ b/08.ls_object/short_format.rb
@@ -12,7 +12,7 @@ class ShortFormat
       end
   end
 
-  def run_ls_short_format
+  def run
     filenames = @pathnames.map(&:basename).map(&:to_s)
     max_filename_count = filenames.map(&:size).max
     row_count = (filenames.count.to_f / DEFAULT_COL_COUNT).ceil

--- a/08.ls_object/test/ls_test.rb
+++ b/08.ls_object/test/ls_test.rb
@@ -1,0 +1,60 @@
+require 'pathname'
+require 'minitest/autorun'
+require_relative '../ls'
+
+class LsTest < Minitest::Test
+  TARGET_PATHNAME = Pathname('test/sample-app')
+
+  def test_run_ls_short_format
+    ls = Ls.new(TARGET_PATHNAME,**{ detail: false, reverse: false, dot_match: false })
+    expected = <<~TEXT.chomp
+    Gemfile           config            postcss.config.js
+    Gemfile.lock      config.ru         public
+    README.md         db                storage
+    Rakefile          lib               test
+    app               log               tmp
+    babel.config.js   node_modules      vendor
+    bin               package.json      yarn.lock
+    TEXT
+    assert_equal expected, ls.run_ls
+  end
+
+  def test_run_ls_long_format
+    ls = Ls.new(TARGET_PATHNAME,**{ detail: true, reverse: false, dot_match: false })
+    expected = `ls -l #{TARGET_PATHNAME}`.chomp
+    assert_equal expected, long_format_files.run_ls_long_format
+  end
+
+  def test_run_ls_reverse
+    ls = Ls.new(TARGET_PATHNAME,**{ detail: false, reverse: true, dot_match: false })
+    expected = <<~TEXT.chomp
+    yarn.lock         package.json      bin
+    vendor            node_modules      babel.config.js
+    tmp               log               app
+    test              lib               Rakefile
+    storage           db                README.md
+    public            config.ru         Gemfile.lock
+    postcss.config.js config            Gemfile
+    TEXT
+    assert_equal expected, ls.run_ls
+  end
+
+  def test_run_ls_dot_match
+    ls = Ls.new(TARGET_PATHNAME,**{ detail: false, reverse: false, dot_match: true })
+    expected = <<~TEXT.chomp
+      .                 README.md         config.ru         postcss.config.js
+      ..                Rakefile          db                public
+      .browserslistrc   app               lib               test
+      .ruby-version     babel.config.js   log               tmp
+      Gemfile           bin               node_modules      vendor
+      Gemfile.lock      config            package.json      yarn.lock
+    TEXT
+    assert_equal expected, ls.run_ls
+  end
+
+  def test_run_ls_all_options
+    ls = Ls.new(TARGET_PATHNAME,**{ detail: true, reverse: true, dot_match: true })
+    expected = `ls -arl #{TARGET_PATHNAME}`.chomp
+    assert_equal expected, ls.run_ls
+  end
+end

--- a/08.ls_object/test/ls_test.rb
+++ b/08.ls_object/test/ls_test.rb
@@ -3,7 +3,7 @@ require 'minitest/autorun'
 require_relative '../ls'
 
 class LsTest < Minitest::Test
-  TARGET_PATHNAME = Pathname('test/sample-app')
+  TARGET_PATHNAME = Pathname('test/sample-app/*')
 
   def test_run_ls_short_format
     ls = Ls.new(TARGET_PATHNAME,**{ detail: false, reverse: false, dot_match: false })
@@ -42,12 +42,15 @@ class LsTest < Minitest::Test
   def test_run_ls_dot_match
     ls = Ls.new(TARGET_PATHNAME,**{ detail: false, reverse: false, dot_match: true })
     expected = <<~TEXT.chomp
-      .                 README.md         config.ru         postcss.config.js
-      ..                Rakefile          db                public
-      .browserslistrc   app               lib               test
-      .ruby-version     babel.config.js   log               tmp
-      Gemfile           bin               node_modules      vendor
-      Gemfile.lock      config            package.json      yarn.lock
+    .                 Rakefile          node_modules
+    ..                app               package.json
+    .browserslistrc   babel.config.js   postcss.config.js
+    .gitignore        bin               public
+    .rubocop.yml      config            storage
+    .ruby-version     config.ru         test
+    Gemfile           db                tmp
+    Gemfile.lock      lib               vendor
+    README.md         log               yarn.lock
     TEXT
     assert_equal expected, ls.run_ls
   end

--- a/08.ls_object/test/ls_test.rb
+++ b/08.ls_object/test/ls_test.rb
@@ -3,10 +3,10 @@ require 'minitest/autorun'
 require_relative '../ls'
 
 class LsTest < Minitest::Test
-  TARGET_PATHNAME = Pathname('test/sample-app/*')
+  TARGET_PATHNAME = 'test/sample-app'
 
   def test_run_ls_short_format
-    ls = Ls.new(TARGET_PATHNAME,**{ detail: false, reverse: false, dot_match: false })
+    ls = Ls.new(Pathname(TARGET_PATHNAME + '/*'),**{ detail: false, reverse: false, dot_match: false })
     expected = <<~TEXT.chomp
     Gemfile           config            postcss.config.js
     Gemfile.lock      config.ru         public
@@ -20,13 +20,13 @@ class LsTest < Minitest::Test
   end
 
   def test_run_ls_long_format
-    ls = Ls.new(TARGET_PATHNAME,**{ detail: true, reverse: false, dot_match: false })
+    ls = Ls.new(Pathname(TARGET_PATHNAME),**{ detail: true, reverse: false, dot_match: false })
     expected = `ls -l #{TARGET_PATHNAME}`.chomp
-    assert_equal expected, long_format_files.run_ls_long_format
+    assert_equal expected, ls.run_ls
   end
 
   def test_run_ls_reverse
-    ls = Ls.new(TARGET_PATHNAME,**{ detail: false, reverse: true, dot_match: false })
+    ls = Ls.new(Pathname(TARGET_PATHNAME + '/*'),**{ detail: false, reverse: true, dot_match: false })
     expected = <<~TEXT.chomp
     yarn.lock         package.json      bin
     vendor            node_modules      babel.config.js
@@ -40,7 +40,7 @@ class LsTest < Minitest::Test
   end
 
   def test_run_ls_dot_match
-    ls = Ls.new(TARGET_PATHNAME,**{ detail: false, reverse: false, dot_match: true })
+    ls = Ls.new(Pathname(TARGET_PATHNAME + '/*'),**{ detail: false, reverse: false, dot_match: true })
     expected = <<~TEXT.chomp
     .                 Rakefile          node_modules
     ..                app               package.json
@@ -56,7 +56,7 @@ class LsTest < Minitest::Test
   end
 
   def test_run_ls_all_options
-    ls = Ls.new(TARGET_PATHNAME,**{ detail: true, reverse: true, dot_match: true })
+    ls = Ls.new(Pathname(TARGET_PATHNAME),**{ detail: true, reverse: true, dot_match: true })
     expected = `ls -arl #{TARGET_PATHNAME}`.chomp
     assert_equal expected, ls.run_ls
   end

--- a/08.ls_object/test/ls_test.rb
+++ b/08.ls_object/test/ls_test.rb
@@ -3,10 +3,10 @@ require 'minitest/autorun'
 require_relative '../ls'
 
 class LsTest < Minitest::Test
-  TARGET_PATHNAME = 'test/sample-app'
+  TARGET_PATHNAME = Pathname('test/sample-app')
 
   def test_run_ls_short_format
-    ls = Ls.new(Pathname(TARGET_PATHNAME + '/*'),**{ detail: false, reverse: false, dot_match: false })
+    ls = Ls.new(TARGET_PATHNAME.join('*'),**{ detail: false, reverse: false, dot_match: false })
     expected = <<~TEXT.chomp
     Gemfile           config            postcss.config.js
     Gemfile.lock      config.ru         public
@@ -20,13 +20,13 @@ class LsTest < Minitest::Test
   end
 
   def test_run_ls_long_format
-    ls = Ls.new(Pathname(TARGET_PATHNAME),**{ detail: true, reverse: false, dot_match: false })
+    ls = Ls.new(TARGET_PATHNAME.join('*'),**{ detail: true, reverse: false, dot_match: false })
     expected = `ls -l #{TARGET_PATHNAME}`.chomp
     assert_equal expected, ls.run_ls
   end
 
   def test_run_ls_reverse
-    ls = Ls.new(Pathname(TARGET_PATHNAME + '/*'),**{ detail: false, reverse: true, dot_match: false })
+    ls = Ls.new(TARGET_PATHNAME.join('*'),**{ detail: false, reverse: true, dot_match: false })
     expected = <<~TEXT.chomp
     yarn.lock         package.json      bin
     vendor            node_modules      babel.config.js
@@ -40,7 +40,7 @@ class LsTest < Minitest::Test
   end
 
   def test_run_ls_dot_match
-    ls = Ls.new(Pathname(TARGET_PATHNAME + '/*'),**{ detail: false, reverse: false, dot_match: true })
+    ls = Ls.new(TARGET_PATHNAME.join('*'),**{ detail: false, reverse: false, dot_match: true })
     expected = <<~TEXT.chomp
     .                 Rakefile          node_modules
     ..                app               package.json
@@ -56,7 +56,7 @@ class LsTest < Minitest::Test
   end
 
   def test_run_ls_all_options
-    ls = Ls.new(Pathname(TARGET_PATHNAME),**{ detail: true, reverse: true, dot_match: true })
+    ls = Ls.new(TARGET_PATHNAME.join('*'),**{ detail: true, reverse: true, dot_match: true })
     expected = `ls -arl #{TARGET_PATHNAME}`.chomp
     assert_equal expected, ls.run_ls
   end

--- a/08.ls_object/test/ls_test.rb
+++ b/08.ls_object/test/ls_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 require 'minitest/autorun'
 require_relative '../ls'
@@ -6,57 +8,57 @@ class LsTest < Minitest::Test
   TARGET_PATHNAME = Pathname('test/sample-app')
 
   def test_run_ls_short_format
-    ls = Ls.new(TARGET_PATHNAME.join('*'),**{ detail: false, reverse: false, dot_match: false })
+    ls = Ls.new(TARGET_PATHNAME.join('*'), **{ detail: false, reverse: false, dot_match: false })
     expected = <<~TEXT.chomp
-    Gemfile           config            postcss.config.js
-    Gemfile.lock      config.ru         public
-    README.md         db                storage
-    Rakefile          lib               test
-    app               log               tmp
-    babel.config.js   node_modules      vendor
-    bin               package.json      yarn.lock
+      Gemfile           config            postcss.config.js
+      Gemfile.lock      config.ru         public
+      README.md         db                storage
+      Rakefile          lib               test
+      app               log               tmp
+      babel.config.js   node_modules      vendor
+      bin               package.json      yarn.lock
     TEXT
     assert_equal expected, ls.run_ls
   end
 
   def test_run_ls_long_format
-    ls = Ls.new(TARGET_PATHNAME.join('*'),**{ detail: true, reverse: false, dot_match: false })
+    ls = Ls.new(TARGET_PATHNAME.join('*'), **{ detail: true, reverse: false, dot_match: false })
     expected = `ls -l #{TARGET_PATHNAME}`.chomp
     assert_equal expected, ls.run_ls
   end
 
   def test_run_ls_reverse
-    ls = Ls.new(TARGET_PATHNAME.join('*'),**{ detail: false, reverse: true, dot_match: false })
+    ls = Ls.new(TARGET_PATHNAME.join('*'), **{ detail: false, reverse: true, dot_match: false })
     expected = <<~TEXT.chomp
-    yarn.lock         package.json      bin
-    vendor            node_modules      babel.config.js
-    tmp               log               app
-    test              lib               Rakefile
-    storage           db                README.md
-    public            config.ru         Gemfile.lock
-    postcss.config.js config            Gemfile
+      yarn.lock         package.json      bin
+      vendor            node_modules      babel.config.js
+      tmp               log               app
+      test              lib               Rakefile
+      storage           db                README.md
+      public            config.ru         Gemfile.lock
+      postcss.config.js config            Gemfile
     TEXT
     assert_equal expected, ls.run_ls
   end
 
   def test_run_ls_dot_match
-    ls = Ls.new(TARGET_PATHNAME.join('*'),**{ detail: false, reverse: false, dot_match: true })
+    ls = Ls.new(TARGET_PATHNAME.join('*'), **{ detail: false, reverse: false, dot_match: true })
     expected = <<~TEXT.chomp
-    .                 Rakefile          node_modules
-    ..                app               package.json
-    .browserslistrc   babel.config.js   postcss.config.js
-    .gitignore        bin               public
-    .rubocop.yml      config            storage
-    .ruby-version     config.ru         test
-    Gemfile           db                tmp
-    Gemfile.lock      lib               vendor
-    README.md         log               yarn.lock
+      .                 Rakefile          node_modules
+      ..                app               package.json
+      .browserslistrc   babel.config.js   postcss.config.js
+      .gitignore        bin               public
+      .rubocop.yml      config            storage
+      .ruby-version     config.ru         test
+      Gemfile           db                tmp
+      Gemfile.lock      lib               vendor
+      README.md         log               yarn.lock
     TEXT
     assert_equal expected, ls.run_ls
   end
 
   def test_run_ls_all_options
-    ls = Ls.new(TARGET_PATHNAME.join('*'),**{ detail: true, reverse: true, dot_match: true })
+    ls = Ls.new(TARGET_PATHNAME.join('*'), **{ detail: true, reverse: true, dot_match: true })
     expected = `ls -arl #{TARGET_PATHNAME}`.chomp
     assert_equal expected, ls.run_ls
   end


### PR DESCRIPTION
フィヨルドブートキャンプのプラクティスでlsコマンドのオブジェクト指向版を実装しました。
- オプションがない時の列数は3列で固定
- シンボリックリンク非対応

ご確認よろしくお願いします。